### PR TITLE
addBookToCollection effect catch fix.

### DIFF
--- a/src/effects/book.ts
+++ b/src/effects/book.ts
@@ -75,7 +75,7 @@ export class BookEffects {
     .mergeMap(book => this.db.insert('books', [ book ])
       .mapTo(this.bookActions.addToCollectionSuccess(book))
       .catch(() => Observable.of(
-        this.bookActions.removeFromCollectionFail(book)
+        this.bookActions.addToCollectionFail(book)
       ))
     );
 


### PR DESCRIPTION
addBookToCollection effect is now dispatching addToCollectionFail in its catch block instead of removeFromCollectionFail.
