### PR TITLE
feat(webpack config): eslint now uses ecmascript 6 to lint webpack config file

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 6
+  }
+}


### PR DESCRIPTION
Tested in my editor, visual studio code.
