### PR TITLE
Register a typed Store class with the DI

### DIFF
--- a/src/guards/book-exists.ts
+++ b/src/guards/book-exists.ts
@@ -2,12 +2,11 @@ import 'rxjs/add/operator/take';
 import 'rxjs/add/operator/first';
 import 'rxjs/add/observable/concat';
 import { Injectable } from '@angular/core';
-import { Store } from '@ngrx/store';
 import { Router, CanActivate, ActivatedRouteSnapshot } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
 
 import { GoogleBooksService } from '../services/google-books';
-import { AppState, hasBook, getCollectionLoaded } from '../reducers';
+import { AppStore, hasBook, getCollectionLoaded } from '../reducers';
 import { BookActions } from '../actions/book';
 
 
@@ -19,7 +18,7 @@ import { BookActions } from '../actions/book';
 @Injectable()
 export class BookExistsGuard implements CanActivate {
   constructor(
-    private store: Store<AppState>,
+    private store: AppStore,
     private googleBooks: GoogleBooksService,
     private bookActions: BookActions,
     private router: Router

--- a/src/main.browser.ts
+++ b/src/main.browser.ts
@@ -3,7 +3,7 @@ import { LocationStrategy, HashLocationStrategy } from '@angular/common';
 import { disableDeprecatedForms, provideForms } from '@angular/forms';
 import { provideRouter, ROUTER_DIRECTIVES } from '@angular/router';
 import { PLATFORM_DIRECTIVES } from '@angular/core';
-import { provideStore } from '@ngrx/store';
+import { provideStore, Store } from '@ngrx/store';
 import { provideDB } from '@ngrx/db';
 import { runEffects } from '@ngrx/effects';
 import { instrumentStore } from '@ngrx/store-devtools';
@@ -12,7 +12,7 @@ import { useLogMonitor } from '@ngrx/store-log-monitor';
 import App from './app';
 import routes from './routes';
 import schema from './db-schema';
-import reducer from './reducers';
+import reducer, { AppStore } from './reducers';
 import effects from './effects';
 import services from './services';
 import actions from './actions';
@@ -30,6 +30,13 @@ bootstrap(App, [
    * Source: https://github.com/ngrx/store/blob/master/src/ng2.ts#L43-L69
    */
   provideStore(reducer),
+
+  /**
+   * registers a typed Store with the DI, allowing us to inject AppStore into
+   * our components instead of the more verbose approach of manually typing
+   * the Store to AppState with Store<AppState>
+   */
+  { provide: AppStore, useExisting: Store },
 
   /**
    * runEffects configures all providers for @ngrx/effects. Observables decorated

--- a/src/pages/book-find.ts
+++ b/src/pages/book-find.ts
@@ -1,10 +1,9 @@
 import 'rxjs/add/operator/let';
 import 'rxjs/add/operator/take';
 import { Component } from '@angular/core';
-import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
 
-import { AppState, getSearchResults, getSearchQuery } from '../reducers';
+import { AppStore, getSearchResults, getSearchQuery } from '../reducers';
 import { BookActions } from '../actions';
 import { BookSearchComponent, QueryInput, SearchOutput } from '../components/book-search';
 import { BookPreviewListComponent, BooksInput } from '../components/book-preview-list';
@@ -39,7 +38,7 @@ export class BookFindPage {
   searchQuery$: Observable<QueryInput>;
   books$: Observable<BooksInput>;
 
-  constructor(private store: Store<AppState>, private bookActions: BookActions) {
+  constructor(private store: AppStore, private bookActions: BookActions) {
     /**
      * Selectors can be applied with the `let` operator, which passes the source
      * observable to the provided function. This allows us an expressive,

--- a/src/pages/book-view.ts
+++ b/src/pages/book-view.ts
@@ -3,10 +3,9 @@ import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/switchMap';
 import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
 
-import { AppState, getBook, isBookInCollection } from '../reducers';
+import { AppStore, getBook, isBookInCollection } from '../reducers';
 import { BookActions } from '../actions/book';
 import {
   BookDetailComponent,
@@ -34,7 +33,7 @@ export class BookViewPage {
   isBookInCollection$: Observable<InCollectionInput>;
 
   constructor(
-    private store: Store<AppState>,
+    private store: AppStore,
     private bookActions: BookActions,
     private route: ActivatedRoute
   ) {

--- a/src/pages/collection.ts
+++ b/src/pages/collection.ts
@@ -1,9 +1,8 @@
 import 'rxjs/add/operator/let';
 import { Component } from '@angular/core';
-import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
 
-import { AppState, getBookCollection } from '../reducers';
+import { AppStore, getBookCollection } from '../reducers';
 import { BookPreviewListComponent, BooksInput } from '../components/book-preview-list';
 import { MD_CARD_DIRECTIVES } from '@angular2-material/card';
 
@@ -28,7 +27,7 @@ import { MD_CARD_DIRECTIVES } from '@angular2-material/card';
 export class CollectionPage {
   books$: Observable<BooksInput>;
 
-  constructor(store: Store<AppState>) {
+  constructor(store: AppStore) {
     this.books$ = store.let(getBookCollection());
   }
 }

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -1,6 +1,8 @@
 import '@ngrx/core/add/operator/select';
 import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/operator/let';
+import { Injectable } from '@angular/core';
+import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
 
 /**
@@ -53,6 +55,10 @@ export interface AppState {
   search: fromSearch.SearchState;
   books: fromBooks.BooksState;
   collection: fromCollection.CollectionState;
+}
+
+@Injectable()
+export class AppStore extends Store<AppState> {
 }
 
 


### PR DESCRIPTION
This allows us to inject `AppStore` into our components instead of the more verbose approach of manually typing the `Store` to `AppState` with `Store<AppState>` every time.
