### PR TITLE
add ngrx-store-freeze

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-typescript-preprocessor": "0.0.21",
     "karma-webpack": "^1.7.0",
+    "ngrx-store-freeze": "^0.1.0",
     "promise-loader": "^1.0.0",
     "raw-loader": "0.5.1",
     "source-map-loader": "^0.1.5",

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -24,6 +24,13 @@ import { compose } from '@ngrx/core/compose';
 import { storeLogger } from 'ngrx-store-logger';
 
 /**
+ * storeFreeze prevents state from being mutated. When mutation occurs, an
+ * exception will be thrown. This is useful during development mode to
+ * ensure that none of the reducers accidentally mutates the state.
+ */
+import { storeFreeze } from 'ngrx-store-freeze';
+
+/**
  * combineReducers is another useful metareducer that takes a map of reducer
  * functions and creates a new reducer that stores the gathers the values
  * of each reducer and stores them using the reducer's key. Think of it
@@ -63,7 +70,7 @@ export interface AppState {
  * wrapping that in storeLogger. Remember that compose applies
  * the result from right to left.
  */
-export default compose(storeLogger(), combineReducers)({
+export default compose(storeFreeze, storeLogger(), combineReducers)({
   search: searchReducer,
   books: booksReducer,
   collection: collectionReducer

--- a/src/reducers/search.ts
+++ b/src/reducers/search.ts
@@ -23,7 +23,7 @@ export default function(state = initialState, action: Action): SearchState {
     case BookActions.SEARCH: {
       const query = action.payload;
 
-      return Object.assign(state, {
+      return Object.assign({}, state, {
         query,
         loading: true
       });


### PR DESCRIPTION
A meta reducer which uses [deep-freeze](https://www.npmjs.com/package/deep-freeze) to prevent accidental state mutations in reducers.

@MikeRyan52 @btroncone 
