### PR TITLE
fix for share function.

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1,9 +1,7 @@
-import 'rxjs/add/operator/publishReplay';
-import 'rxjs/add/operator/multicast';
-import { Scheduler } from 'rxjs/Scheduler';
 import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { Scheduler } from 'rxjs/Scheduler';
+import { multicast } from 'rxjs/operator/multicast';
 import { Observable } from 'rxjs/Observable';
-import { compose } from '@ngrx/core/compose';
 
 /**
  * This function coerces a string into a string literal type.
@@ -30,12 +28,42 @@ export interface Selector<T, V> {
   (input: Observable<T>): Observable<V>;
 }
 
-export function share<T, V>(selector: Selector<T, V>): Selector<T, V> {
-  let result: Observable<V>;
+/**
+ * This operator behaves like shareReplay(https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/sharereplay.md) 
+ * with the difference that it will not replay the last known value when the subscribers go from 1 to 0 and then again from 0 to 1.
+ */
+export function shareLatest<T>(windowTime: number = Number.POSITIVE_INFINITY,
+                                 scheduler?: Scheduler): Observable<T> {
+  return multicast.call(this, () => new ReplaySubject<T>(1, windowTime, scheduler)).refCount();
+}
 
-  return function(input: Observable<T>) {
+export interface ShareLatestSignature<T> {
+  (windowTime?: number, scheduler?: Scheduler): Observable<T>;
+}
+
+Observable.prototype.shareLatest = shareLatest;
+
+declare module 'rxjs/Observable' {
+  interface Observable<T> {
+    shareLatest: ShareLatestSignature<T>;
+  }
+}
+
+/**
+ * Chain the selector and shareLatest on the source observable and memoizes the resulting observable.
+ * Multiple subscribers using the same selector and source observable will share the same observable. 
+ * This results in improved performance since the selector will only run when the number of subscribers
+ * goes from 0 to 1. Any additional subscriber will receive the latest emitted value from the source.
+ * 
+ */
+export function share<T, V>(selector: Selector<T, V>): Selector<T, V> {
+  let cache = new Map<Observable<T>, Observable<V>>();
+
+  return function(source: Observable<T>) {
+    let result = cache.get(source);
     if (!result) {
-      result = selector(input).multicast(() => new ReplaySubject<V>(1)).refCount();
+      result = selector(source).shareLatest();
+      cache.set(source);
     }
 
     return result;


### PR DESCRIPTION
This performs the following changes:
- apply a variant of shareReplay.
- map the memoized observable to the source observable

The first change ensures that the selector runs only when refCount go from 0 to 1
and that subscribers will always receive the latest value from the source.

The second change ensures that if a memoized selector is called with different source observables, it returns distinct results.
