### PR TITLE
Update action types definitions in order to work with typescript 2.1.4

### DIFF
--- a/src/app/actions/book.ts
+++ b/src/app/actions/book.ts
@@ -10,11 +10,11 @@ import { type } from '../util';
  * literal types and runs a simple check to guarantee all
  * action types in the application are unique. 
  */
-export const ActionTypes = new class {
-  readonly SEARCH =           type('[Book] Search')
-  readonly SEARCH_COMPLETE =  type('[Book] Search Complete')
-  readonly LOAD =             type('[Book] Load')
-  readonly SELECT =           type('[Book] Select')
+export class ActionTypes {
+  static readonly SEARCH =           type('[Book] Search')
+  static readonly SEARCH_COMPLETE =  type('[Book] Search Complete')
+  static readonly LOAD =             type('[Book] Load')
+  static readonly SELECT =           type('[Book] Select')
 };
 
 

--- a/src/app/actions/book.ts
+++ b/src/app/actions/book.ts
@@ -10,11 +10,11 @@ import { type } from '../util';
  * literal types and runs a simple check to guarantee all
  * action types in the application are unique. 
  */
-export const ActionTypes = {
-  SEARCH:           type('[Book] Search'),
-  SEARCH_COMPLETE:  type('[Book] Search Complete'),
-  LOAD:             type('[Book] Load'),
-  SELECT:           type('[Book] Select'),
+export const ActionTypes = new class {
+  readonly SEARCH =           type('[Book] Search')
+  readonly SEARCH_COMPLETE =  type('[Book] Search Complete')
+  readonly LOAD =             type('[Book] Load')
+  readonly SELECT =           type('[Book] Select')
 };
 
 
@@ -26,25 +26,25 @@ export const ActionTypes = {
  * See Discriminated Unions: https://www.typescriptlang.org/docs/handbook/advanced-types.html#discriminated-unions
  */
 export class SearchAction implements Action {
-  type = ActionTypes.SEARCH;
+  readonly type = ActionTypes.SEARCH;
 
   constructor(public payload: string) { }
 }
 
 export class SearchCompleteAction implements Action {
-  type = ActionTypes.SEARCH_COMPLETE;
+  readonly type = ActionTypes.SEARCH_COMPLETE;
 
   constructor(public payload: Book[]) { }
 }
 
 export class LoadAction implements Action {
-  type = ActionTypes.LOAD;
+  readonly type = ActionTypes.LOAD;
 
   constructor(public payload: Book) { }
 }
 
 export class SelectAction implements Action {
-  type = ActionTypes.SELECT;
+  readonly type = ActionTypes.SELECT;
 
   constructor(public payload: string) { }
 }

--- a/src/app/actions/collection.ts
+++ b/src/app/actions/collection.ts
@@ -3,16 +3,16 @@ import { Book } from '../models/book';
 import { type } from '../util';
 
 
-export const ActionTypes = {
-  ADD_BOOK:             type('[Collection] Add Book'),
-  ADD_BOOK_SUCCESS:     type('[Collection] Add Book Success'),
-  ADD_BOOK_FAIL:        type('[Collection] Add Book Fail'),
-  REMOVE_BOOK:          type('[Collection] Remove Book'),
-  REMOVE_BOOK_SUCCESS:  type('[Collection] Remove Book Success'),
-  REMOVE_BOOK_FAIL:     type('[Collection] Remove Book Fail'),
-  LOAD:                 type('[Collection] Load'),
-  LOAD_SUCCESS:         type('[Collection] Load Success'),
-  LOAD_FAIL:            type('[Collection] Load Fail'),
+export const ActionTypes = new class{
+  readonly ADD_BOOK =             type('[Collection] Add Book')
+  readonly ADD_BOOK_SUCCESS =     type('[Collection] Add Book Success')
+  readonly ADD_BOOK_FAIL =        type('[Collection] Add Book Fail')
+  readonly REMOVE_BOOK =          type('[Collection] Remove Book')
+  readonly REMOVE_BOOK_SUCCESS =  type('[Collection] Remove Book Success')
+  readonly REMOVE_BOOK_FAIL =     type('[Collection] Remove Book Fail')
+  readonly LOAD =                 type('[Collection] Load')
+  readonly LOAD_SUCCESS =         type('[Collection] Load Success')
+  readonly LOAD_FAIL =            type('[Collection] Load Fail')
 };
 
 
@@ -20,19 +20,19 @@ export const ActionTypes = {
  * Add Book to Collection Actions
  */
 export class AddBookAction implements Action {
-  type = ActionTypes.ADD_BOOK;
+  readonly type =ActionTypes.ADD_BOOK;
 
   constructor(public payload: Book) { }
 }
 
 export class AddBookSuccessAction implements Action {
-  type = ActionTypes.ADD_BOOK_SUCCESS;
+  readonly type =ActionTypes.ADD_BOOK_SUCCESS;
 
   constructor(public payload: Book) { }
 }
 
 export class AddBookFailAction implements Action {
-  type = ActionTypes.ADD_BOOK_FAIL;
+  readonly type =ActionTypes.ADD_BOOK_FAIL;
 
   constructor(public payload: Book) { }
 }
@@ -42,19 +42,19 @@ export class AddBookFailAction implements Action {
  * Remove Book from Collection Actions
  */
 export class RemoveBookAction implements Action {
-  type = ActionTypes.REMOVE_BOOK;
+  readonly type =ActionTypes.REMOVE_BOOK;
 
   constructor(public payload: Book) { }
 }
 
 export class RemoveBookSuccessAction implements Action {
-  type = ActionTypes.REMOVE_BOOK_SUCCESS;
+  readonly type =ActionTypes.REMOVE_BOOK_SUCCESS;
 
   constructor(public payload: Book) { }
 }
 
 export class RemoveBookFailAction implements Action {
-  type = ActionTypes.REMOVE_BOOK_FAIL;
+  readonly type =ActionTypes.REMOVE_BOOK_FAIL;
 
   constructor(public payload: Book) { }
 }
@@ -63,19 +63,19 @@ export class RemoveBookFailAction implements Action {
  * Load Collection Actions
  */
 export class LoadAction implements Action {
-  type = ActionTypes.LOAD;
+  readonly type =ActionTypes.LOAD;
 
   constructor() { }
 }
 
 export class LoadSuccessAction implements Action {
-  type = ActionTypes.LOAD_SUCCESS;
+  readonly type =ActionTypes.LOAD_SUCCESS;
 
   constructor(public payload: Book[]) { }
 }
 
 export class LoadFailAction implements Action {
-  type = ActionTypes.LOAD_FAIL;
+  readonly type =ActionTypes.LOAD_FAIL;
 
   constructor(public payload: any) { }
 }

--- a/src/app/actions/collection.ts
+++ b/src/app/actions/collection.ts
@@ -3,16 +3,16 @@ import { Book } from '../models/book';
 import { type } from '../util';
 
 
-export const ActionTypes = new class{
-  readonly ADD_BOOK =             type('[Collection] Add Book')
-  readonly ADD_BOOK_SUCCESS =     type('[Collection] Add Book Success')
-  readonly ADD_BOOK_FAIL =        type('[Collection] Add Book Fail')
-  readonly REMOVE_BOOK =          type('[Collection] Remove Book')
-  readonly REMOVE_BOOK_SUCCESS =  type('[Collection] Remove Book Success')
-  readonly REMOVE_BOOK_FAIL =     type('[Collection] Remove Book Fail')
-  readonly LOAD =                 type('[Collection] Load')
-  readonly LOAD_SUCCESS =         type('[Collection] Load Success')
-  readonly LOAD_FAIL =            type('[Collection] Load Fail')
+export class ActionTypes {
+  static readonly ADD_BOOK =             type('[Collection] Add Book')
+  static readonly ADD_BOOK_SUCCESS =     type('[Collection] Add Book Success')
+  static readonly ADD_BOOK_FAIL =        type('[Collection] Add Book Fail')
+  static readonly REMOVE_BOOK =          type('[Collection] Remove Book')
+  static readonly REMOVE_BOOK_SUCCESS =  type('[Collection] Remove Book Success')
+  static readonly REMOVE_BOOK_FAIL =     type('[Collection] Remove Book Fail')
+  static readonly LOAD =                 type('[Collection] Load')
+  static readonly LOAD_SUCCESS =         type('[Collection] Load Success')
+  static readonly LOAD_FAIL =            type('[Collection] Load Fail')
 };
 
 

--- a/src/app/actions/layout.ts
+++ b/src/app/actions/layout.ts
@@ -1,18 +1,18 @@
 import { Action } from '@ngrx/store';
 import { type } from '../util';
 
-export const ActionTypes = {
-  OPEN_SIDENAV:   type('[Layout] Open Sidenav'),
-  CLOSE_SIDENAV:  type('[Layout] Close Sidenav')
+export const ActionTypes = new class {
+  readonly OPEN_SIDENAV =   type('[Layout] Open Sidenav')
+  readonly CLOSE_SIDENAV =  type('[Layout] Close Sidenav')
 };
 
 
 export class OpenSidenavAction implements Action {
-  type = ActionTypes.OPEN_SIDENAV;
+  readonly type = ActionTypes.OPEN_SIDENAV;
 }
 
 export class CloseSidenavAction implements Action {
-  type = ActionTypes.CLOSE_SIDENAV;
+  readonly type = ActionTypes.CLOSE_SIDENAV;
 }
 
 

--- a/src/app/actions/layout.ts
+++ b/src/app/actions/layout.ts
@@ -1,9 +1,9 @@
 import { Action } from '@ngrx/store';
 import { type } from '../util';
 
-export const ActionTypes = new class {
-  readonly OPEN_SIDENAV =   type('[Layout] Open Sidenav')
-  readonly CLOSE_SIDENAV =  type('[Layout] Close Sidenav')
+export class ActionTypes  {
+  static readonly OPEN_SIDENAV =   type('[Layout] Open Sidenav')
+  static readonly CLOSE_SIDENAV =  type('[Layout] Close Sidenav')
 };
 
 

--- a/src/app/util.ts
+++ b/src/app/util.ts
@@ -9,7 +9,7 @@
  */
 
 let typeCache: { [label: string]: boolean } = {};
-export function type<T>(label: T | ''): T {
+export function type<T extends string>(label: T): T {
   if (typeCache[<string>label]) {
     throw new Error(`Action type "${label}" is not unique"`);
   }


### PR DESCRIPTION
This allows the example-app to be used with typescript 2.1.4.

> The type inferred for a const variable or readonly property without a type annotation is the type of the initializer as-is.

> The type inferred for a let variable, var variable, parameter, or non-readonly property with an initializer and no type annotation is the widened literal type of the initializer.

This means that when not using `readonly` or `const` the variable / property will be a string, instead of 
a string literal type ( `'[Book] Search'` )

This does not affect previous versions of typescript
