### PR TITLE
Remove StateUpdates Update documentation in effects example

### DIFF
--- a/src/app/effects/book.ts
+++ b/src/app/effects/book.ts
@@ -17,10 +17,13 @@ import * as book from '../actions/book';
 
 /**
  * Effects offer a way to isolate and easily test side-effects within your
- * application. StateUpdates is an observable of the latest state and
- * dispatched action. The `toPayload` helper function returns just
+ * application. 
+ * Here `.map((action: book.SearchAction) => action.payload)` could be
+ * replaced with the `toPayload` helper function which returns just
  * the payload of the currently dispatched action, useful in
  * instances where the current state is not necessary.
+ * Documentation on `toPayload` can be found here:
+ * https://github.com/ngrx/effects/blob/master/docs/api.md#topayload
  *
  * If you are unfamiliar with the operators being used in these examples, please
  * check out the sources below:

--- a/src/app/effects/book.ts
+++ b/src/app/effects/book.ts
@@ -5,7 +5,7 @@ import 'rxjs/add/operator/debounceTime';
 import 'rxjs/add/operator/skip';
 import 'rxjs/add/operator/takeUntil';
 import { Injectable } from '@angular/core';
-import { Effect, Actions } from '@ngrx/effects';
+import { Effect, Actions, toPayload } from '@ngrx/effects';
 import { Action } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
 import { empty } from 'rxjs/observable/empty';
@@ -17,11 +17,11 @@ import * as book from '../actions/book';
 
 /**
  * Effects offer a way to isolate and easily test side-effects within your
- * application. 
- * Here `.map((action: book.SearchAction) => action.payload)` could be
- * replaced with the `toPayload` helper function which returns just
+ * application.
+ * The `toPayload` helper function returns just
  * the payload of the currently dispatched action, useful in
  * instances where the current state is not necessary.
+ *
  * Documentation on `toPayload` can be found here:
  * https://github.com/ngrx/effects/blob/master/docs/api.md#topayload
  *
@@ -41,7 +41,7 @@ export class BookEffects {
   search$: Observable<Action> = this.actions$
     .ofType(book.ActionTypes.SEARCH)
     .debounceTime(300)
-    .map((action: book.SearchAction) => action.payload)
+    .map(toPayload)
     .switchMap(query => {
       if (query === '') {
         return empty();


### PR DESCRIPTION
- Removes deprecated `StateUpdates`
- Updates explanation for `toPayload`

This came up in the gitter room, figured I would submit a PR to clean this up, let me know if I should change any wording, or remove anything else, etc. 