### PR TITLE
Move the debounce part at a lower level to avoid updating the store unnecessarily

### DIFF
--- a/src/app/components/book-search.ts
+++ b/src/app/components/book-search.ts
@@ -1,23 +1,34 @@
 import 'rxjs/add/operator/debounceTime';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/distinctUntilChanged';
-import { Component, Output, Input, EventEmitter } from '@angular/core';
+import {
+    Component,
+    Output,
+    Input,
+    EventEmitter,
+    ElementRef,
+    ViewChild,
+    NgZone,
+    ChangeDetectorRef,
+    AfterViewInit
+} from '@angular/core';
+import { Observable } from 'rxjs';
 
 
 @Component({
-  selector: 'bc-book-search',
-  template: `
+    selector:'bc-book-search',
+    template:`
     <md-card>
       <md-card-title>Find a Book</md-card-title>
       <md-card-content>
         <md-input-container>
-          <input mdInput placeholder="Search for a book" [value]="query" (keyup)="search.emit($event.target.value)">
+          <input mdInput placeholder="Search for a book" [value]="query" #search>
         </md-input-container>
         <md-spinner [class.show]="searching"></md-spinner>
       </md-card-content>
     </md-card>
   `,
-  styles: [`
+    styles:[`
     md-card-title,
     md-card-content {
       display: flex;
@@ -46,8 +57,24 @@ import { Component, Output, Input, EventEmitter } from '@angular/core';
     }
   `]
 })
-export class BookSearchComponent {
-  @Input() query = '';
-  @Input() searching = false;
-  @Output() search = new EventEmitter<string>();
+export class BookSearchComponent implements AfterViewInit {
+    @Input() query = '';
+    @Input() searching = false;
+    @Output() search = new EventEmitter<string>();
+    
+    @ViewChild('search') inputRef:ElementRef;
+    
+    constructor(private zone:NgZone, private cd:ChangeDetectorRef) {}
+    
+    ngAfterViewInit() {
+        this.zone.runOutsideAngular(() => {
+            console.log('this.inputRef:', this.inputRef);
+            Observable.fromEvent(this.inputRef.nativeElement, 'keyup')
+                .debounceTime(300)
+                .subscribe((keyboardEvent:any) => {
+                  this.search.emit(keyboardEvent.target.value);
+                  this.cd.detectChanges();
+                });
+        });
+    }
 }

--- a/src/app/effects/book.ts
+++ b/src/app/effects/book.ts
@@ -38,7 +38,6 @@ export class BookEffects {
   @Effect()
   search$: Observable<Action> = this.actions$
     .ofType(book.ActionTypes.SEARCH)
-    .debounceTime(300)
     .map(toPayload)
     .switchMap(query => {
       if (query === '') {


### PR DESCRIPTION
Indeed, it seems to me that putting a debounce on the SEARCH_COMPLETE action is not enough because the SEARCH action will still be invoked for each stroke.
The idea here is to debounce directly the keystrokes event avoiding a store update for each stroke.